### PR TITLE
[DM-4888] Update documentation to support git-lfs 1.1.0+.

### DIFF
--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -24,12 +24,7 @@ Most package managers also provide the ``git-lfs`` client.
 Since, LFS is a rapidly evolving technology, package managers will help you keep up with new ``git-lfs`` releases.
 For example, Mac users with Homebrew_ can simply run ``brew install git-lfs`` and ``brew upgrade git-lfs``.
 
-.. _git-lfs-config:
-
-Configuring Git and Git LFS
-===========================
-
-Once ``git-lfs`` is installed, run
+Once ``git-lfs`` is installed, run:
 
 .. code-block:: bash
 
@@ -38,67 +33,56 @@ Once ``git-lfs`` is installed, run
 
 to configure Git to use Git LFS in your :file:`~/.gitconfig` file.
 
-Next, we need to tell Git that DM's LFS storage services don't need a password for reading.
-Begin by activating Git's `credential store`_ helper for DM's Git LFS storage services by adding these lines into your :file:`~/.gitconfig` file:
-
-.. code-block:: text
-
-   [credential "https://lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com"]
-           helper = store
-   [credential "https://s3.lsst.codes"]
-           helper = store
-
-Then add DM's Git LFS storage servers to your :file:`~/.git-credentials` file:
-
-.. code-block:: text
-   
-   https://:@lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com
-   https://:@s3.lsst.codes
-
-*Notice that the username is purposefully missing from these lines; this tells the Git credential store that you're opting for anonymous access.*
-
-Next, decide whether you will need to push Git LFS data, or only clone and pull form Git LFS managed repositories.
-This affects how you set up authentication to DM's Git LFS server (we only configured anonymous access to the *storage services* so far).
+Next, decide whether you will need to push Git LFS data, or only clone and pull from Git LFS managed repositories.
+This affects how you set up authentication to DM's Git LFS servers.
 The two configuration options are:
 
-1. :ref:`Anonymous access for read-only LFS users <git-lfs-anon>`
-2. :ref:`Authenticated access for read-write LFS users <git-lfs-auth>`
+1. :ref:`Anonymous access for read-only LFS users <git-lfs-anon>`.
+2. :ref:`Authenticated access for read-write LFS users <git-lfs-auth>`.
 
 .. _git-lfs-anon:
 
 Option 1: Anonymous access for read-only LFS users
 --------------------------------------------------
 
-Follow these configuration instructions if you never intend to create a new Git LFS managed repository for DM, or push changes to LFS managed datasets.
+*Follow these configuration instructions if you never intend to create a new Git LFS managed repository for DM, or push changes to LFS managed datasets.*
 Skip to configuration :ref:`Option 2 <git-lfs-auth>` if this isn't the case for you.
 
-.. If you are anonymously authenticating then you must configure git to use an empty username and password with the git-lfs server. Add this to your :file:`~/.gitconfig` file.
-For anonymous access to DM's Git LFS server, use the now-familiar pattern of activating a `credential store`_ helper by pasting these lines into :file:`~/.gitconfig`:
+First, paste these lines into your :file:`~/.gitconfig` file:
 
-.. code-block:: text
+.. literalinclude:: snippets/git_lfs_gitconfig.txt
+   :language: text
 
-   [credential "https://git-lfs.lsst.codes"]
-           helper = store
+Then paste these lines into your :file:`~/.git-credentials` files (create one, if necessary):
 
-Then add cache anonymous access to the server by adding this line to your :file:`~/.git-credentials` file:
+.. literalinclude:: snippets/git_lfs_git-credentials.txt
+   :language: text
 
-.. code-block:: text
-   
-   https://:@git-lfs.lsst.codes
-
-That's it. You're ready to clone any of DM's Git LFS managed repositories.
+*That's it.*
+You're ready to clone any of DM's Git LFS managed repositories.
 
 .. _git-lfs-auth:
 
 Option 2: Authenticated access for read-write LFS users
 -------------------------------------------------------
 
-**Follow these configuration instructions if you need to create or push changes to a DM Git LFS managed repository.
-Only GitHub users in the LSST GitHub organization can authenticate with DM's storage service.**
+*Follow these configuration instructions if you need to create or push changes to a DM Git LFS managed repository.
+Only GitHub users in the LSST GitHub organization can authenticate with DM's storage service.*
 If you only want read-only access to DM's Git LFS managed repositories, return to :ref:`Option 1 <git-lfs-anon>`.
 
-Git LFS mandates the HTTPS transport protocol.
-Since many HTTPS authentications happen during a single clone, push or fetch operation, it is essential that you use a Git credential helper to work effectively with Git LFS.
+First, paste these lines into your :file:`~/.gitconfig` file:
+
+.. literalinclude:: snippets/git_lfs_gitconfig.txt
+   :language: text
+   :lines: 1-5
+
+Then paste these lines into your :file:`~/.git-credentials` files (create one, if necessary):
+
+.. literalinclude:: snippets/git_lfs_git-credentials.txt
+   :language: text
+   :lines: 1-2
+
+Next, setup a credential helper to manage your GitHub credentials (Git LFS won't use your SSH keys).
 :ref:`We describe how to setup a credential helper for your system in the Git setup guide <git-credential-helper>`.
 
 Once a helper is setup, you can cache your credentials by cloning any of DM's LFS-backed repositories.
@@ -119,6 +103,9 @@ At the prompts, enter your GitHub username and password.
 You can setup a personal token at https://github.com/settings/tokens.
 
 Once your credentials are cached, you won't need to repeat this process on your system (:ref:`unless you opted for the cache-based credential helper <git-credential-helper>`).
+
+*That's it.*
+Read the rest of this page to learn how to work with Git LFS repositories.
 
 .. _git-lfs-using:
 
@@ -213,4 +200,3 @@ New LFS-managed repos should use :file:`.lfsconfig`.
 We also recommend that you include a link to this documentation page in your :file:`README` to help those who aren't familiar with DM's Git LFS.
 
 .. _Homebrew: http://brew.sh
-.. _credential store: http://git-scm.com/docs/git-credential-store

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -48,12 +48,12 @@ Option 1: Anonymous access for read-only LFS users
 *Follow these configuration instructions if you never intend to create a new Git LFS managed repository for DM, or push changes to LFS managed datasets.*
 Skip to configuration :ref:`Option 2 <git-lfs-auth>` if this isn't the case for you.
 
-First, paste these lines into your :file:`~/.gitconfig` file:
+First, add these lines into your :file:`~/.gitconfig` file:
 
 .. literalinclude:: snippets/git_lfs_gitconfig.txt
    :language: text
 
-Then paste these lines into your :file:`~/.git-credentials` files (create one, if necessary):
+Then add these lines into your :file:`~/.git-credentials` files (create one, if necessary):
 
 .. literalinclude:: snippets/git_lfs_git-credentials.txt
    :language: text
@@ -70,13 +70,13 @@ Option 2: Authenticated access for read-write LFS users
 Only GitHub users in the LSST GitHub organization can authenticate with DM's storage service.*
 If you only want read-only access to DM's Git LFS managed repositories, return to :ref:`Option 1 <git-lfs-anon>`.
 
-First, paste these lines into your :file:`~/.gitconfig` file:
+First, add these lines into your :file:`~/.gitconfig` file:
 
 .. literalinclude:: snippets/git_lfs_gitconfig.txt
    :language: text
    :lines: 1-5
 
-Then paste these lines into your :file:`~/.git-credentials` files (create one, if necessary):
+Then add these lines into your :file:`~/.git-credentials` files (create one, if necessary):
 
 .. literalinclude:: snippets/git_lfs_git-credentials.txt
    :language: text

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -63,9 +63,9 @@ Next add their authentication information to your :file:`~/.git-credentials` fil
 If you are anonymously authenticating then you must configure git to use an empty username and password with the git-lfs server. Add this to your :file:`~/.gitconfig` file.
 
 .. code-block:: text
-   
-   https://:@lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com
-   https://:@s3.lsst.codes
+
+   [credential "https://git-lfs.lsst.codes"]
+           helper = store
 
 Add this to your :file:`~/.git-credentials` file.
 

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -56,7 +56,9 @@ Next add their authentication information to your :file:`~/.git-credentials` fil
 
 .. _git-lfs-anonymous:
 
-.. note:: This step is only required if you are anonymously authenticating with Git LFS.
+.. note::
+
+   This step is only required if you are anonymously authenticating with Git LFS.
 
 If you are anonymously authenticating then you must configure git to use an empty username and password with the git-lfs server. Add this to your :file:`~/.gitconfig` file.
 

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -58,7 +58,7 @@ Next add their authentication information to your :file:`~/.git-credentials` fil
 
 .. note::
 
-   This step is only required if you are anonymously authenticating with Git LFS.
+   Anonymous authentication with the Git LFS server is optional. You will only be able to pull and clone the repository with this configuration.
 
 If you are anonymously authenticating then you must configure git to use an empty username and password with the git-lfs server. Add this to your :file:`~/.gitconfig` file.
 

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -96,7 +96,7 @@ For example, run:
 
 - If you are a member of the LSST GitHub organization you can use your GitHub username and password.
 - If you *also* have `GitHub's two-factor authentication <https://help.github.com/articles/about-two-factor-authentication/>`_ enabled, use a personal access token instead of a password. You can setup a personal token at https://github.com/settings/tokens.
-- If you are only interested in cloning or pulling, :ref:`configure anonymous authentication<git-lfs-anonymous>` for the git-lfs server.
+- If you are only interested in cloning or pulling, :ref:`configure anonymous authentication <git-lfs-anonymous>` for the git-lfs server.
 
 Once your credentials are cached, you won't need to repeat this process on your system (:ref:`unless you opted for the cache-based credential helper <git-credential-helper>`).
 

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -35,7 +35,7 @@ to install the necessary configuration in your :file:`~/.gitconfig` file.
 
 Next add credentials for our git-lfs secondary storage systems to your :file:`~/.gitconfig` file.
 
-.. code-block:: bash
+.. code-block::
 
 [credential "https://lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com"]
         helper = store
@@ -44,20 +44,23 @@ Next add credentials for our git-lfs secondary storage systems to your :file:`~/
 
 Next add their authentication information to your :file:`~/.git-credentials` file.
 
-.. code-block:: bash
+.. code-block::
+   
 https://:@lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com
 https://:@s3.lsst.codes
 
 
 If you will be anonymously authenticating then you must configure git to use no username and password with the git-lfs server. Add this to your :file:`~/.gitconfig` file.
 
-.. code-block:: bash
+.. code-block::
+   
 https://:@lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com
 https://:@s3.lsst.codes
 
 Add this to your :file:`~/.git-credentials` file.
 
-.. code-block:: bash
+.. code-block::
+   
 https://:@git-lfs.lsst.codes
 
 .. _git-lfs-auth:

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -36,9 +36,10 @@ Once ``git-lfs`` is installed, run
    git config --global lfs.batch false
    git lfs install
 
-to install the necessary configuration in your :file:`~/.gitconfig` file.
+to configure Git to use Git LFS in your :file:`~/.gitconfig` file.
 
-Next add credentials for our git-lfs secondary storage systems to your :file:`~/.gitconfig` file.
+Next, we need to tell Git that DM's LFS storage services don't need a password for reading.
+Begin by activating Git's `credential store`_ helper for DM's Git LFS storage services by pasting these lines into your :file:`~/.gitconfig` file:
 
 .. code-block:: text
 
@@ -47,44 +48,58 @@ Next add credentials for our git-lfs secondary storage systems to your :file:`~/
    [credential "https://s3.lsst.codes"]
            helper = store
 
-Next add their authentication information to your :file:`~/.git-credentials` file.
+Then add DM's Git LFS storage servers to your :file:`~/.git-credentials` file:
 
 .. code-block:: text
    
    https://:@lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com
    https://:@s3.lsst.codes
 
-.. _git-lfs-anonymous:
+*Notice that the username is purposefully missing from these lines; this tells the Git credential store that you're opting for anonymous access.*
 
-.. note::
+Next, decide whether you will need to push Git LFS data, or only clone and pull form Git LFS managed repositories.
+This affects how you set up authentication to DM's Git LFS server (we only configured anonymous access to the *storage services* so far).
+The two configuration options are:
 
-   Anonymous authentication with the Git LFS server is optional. You will only be able to pull and clone the repository with this configuration.
+1. :ref:`Anonymous access for read-only LFS users <git-lfs-anon>`
+2. :ref:`Authenticated access for read-write LFS users <git-lfs-auth>`
 
-If you are anonymously authenticating then you must configure git to use an empty username and password with the git-lfs server. Add this to your :file:`~/.gitconfig` file.
+.. _git-lfs-anon:
+
+Option 1: Anonymous access for read-only LFS users
+--------------------------------------------------
+
+Follow these configuration instructions if you never intend to create a new Git LFS managed repository for DM, or push changes to LFS managed datasets.
+Skip to configuration :ref:`Option 2 <git-lfs-auth>` if this isn't the case for you.
+
+.. If you are anonymously authenticating then you must configure git to use an empty username and password with the git-lfs server. Add this to your :file:`~/.gitconfig` file.
+For anonymous access to DM's Git LFS server, use the now-familiar pattern of activating a `credential store`_ helper by pasting these lines into :file:`~/.gitconfig`:
 
 .. code-block:: text
 
    [credential "https://git-lfs.lsst.codes"]
            helper = store
 
-Add this to your :file:`~/.git-credentials` file.
+Then add cache anonymous access to the server by adding this line to your :file:`~/.git-credentials` file:
 
 .. code-block:: text
    
    https://:@git-lfs.lsst.codes
 
+**That's it. You're ready to clone any of DM's Git LFS managed repositories.**
+
 .. _git-lfs-auth:
 
-Setting up Git LFS authentication
-=================================
+Option 2: Authenticated access for read-write LFS users
+-------------------------------------------------------
 
-Credentials are required to push to an LFS-based repository on GitHub.
-Only GitHub users in the LSST GitHub organization can authenticate with DM's storage service.
-(Credentials *are not needed to clone or pull* from LFS-backed repositories.)
+**Follow these configuration instructions if you need to create or push changes to a DM Git LFS managed repository.
+Only GitHub users in the LSST GitHub organization can authenticate with DM's storage service.**
+If you only want read-only access to DM's Git LFS managed repositories, return to :ref:`Option 1 <git-lfs-anon>`.
 
 Git LFS mandates the HTTPS transport protocol.
 Since many HTTPS authentications happen during a single clone, push or fetch operation, it is essential that you use a Git credential helper to work effectively with Git LFS.
-:ref:`We describe how to setup a credential helper for your system in the deverloper workflow documentation <git-credential-helper>`.
+:ref:`We describe how to setup a credential helper for your system in the Git setup guide <git-credential-helper>`.
 
 Once a helper is setup, you can cache your credentials by cloning any of DM's LFS-backed repositories.
 For example, run:
@@ -98,9 +113,10 @@ For example, run:
    Username for 'https://git-lfs.lsst.codes': <GitHub username>
    Password for 'https://<git>@git-lfs.lsst.codes': <GitHub password>
 
-- If you are a member of the LSST GitHub organization you can use your GitHub username and password.
-- If you *also* have `GitHub's two-factor authentication <https://help.github.com/articles/about-two-factor-authentication/>`_ enabled, use a personal access token instead of a password. You can setup a personal token at https://github.com/settings/tokens.
-- If you are only interested in cloning or pulling, :ref:`configure anonymous authentication <git-lfs-anonymous>` for the git-lfs server.
+At the prompts, enter your GitHub username and password.
+
+*If you have* `GitHub's two-factor authentication <https://help.github.com/articles/about-two-factor-authentication/>`_ enabled, use a personal access token instead of a password.
+You can setup a personal token at https://github.com/settings/tokens.
 
 Once your credentials are cached, you won't need to repeat this process on your system (:ref:`unless you opted for the cache-based credential helper <git-credential-helper>`).
 
@@ -116,7 +132,7 @@ All of the regular Git commands just work, whether you are working with LFS-mana
 There are two caveats for working with LFS: HTTPS is always used, and Git LFS must be told to track new binary file types.
 
 First, DM's LFS implementation mandates the HTTPS transport protocol.
-Developers used to working with `ssh-agent <http://www.openbsd.org/cgi-bin/man.cgi?query=ssh-agent&sektion=1>`_ for passwordless GitHub interaction should use a :ref:`Git credential helper <git-credential-helper>`, and follow the directions above for configuring their credentials.
+Developers used to working with `ssh-agent <http://www.openbsd.org/cgi-bin/man.cgi?query=ssh-agent&sektion=1>`_ for passwordless GitHub interaction should use a :ref:`Git credential helper <git-credential-helper>`, and follow the :ref:`directions above <git-lfs-auth>` for configuring their credentials.
 
 Note this *does not* preclude using ``git+git`` or ``git+ssh`` for working with a Git remote itself; it is only the LFS traffic that always uses HTTPS.
 
@@ -197,3 +213,4 @@ New LFS-managed repos should use :file:`.lfsconfig`.
 We also recommend that you include a link to this documentation page in your :file:`README` to help those who aren't familiar with DM's Git LFS.
 
 .. _Homebrew: http://brew.sh
+.. _credential store: http://git-scm.com/docs/git-credential-store

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -56,7 +56,9 @@ Next add their authentication information to your :file:`~/.git-credentials` fil
 
 .. _git-lfs-anonymous:
 
-If you will be anonymously authenticating then you must configure git to use no username and password with the git-lfs server. Add this to your :file:`~/.gitconfig` file.
+.. note:: This step is only required if you are anonymously authenticating with Git LFS.
+
+If you are anonymously authenticating then you must configure git to use an empty username and password with the git-lfs server. Add this to your :file:`~/.gitconfig` file.
 
 .. code-block:: text
    

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -24,6 +24,11 @@ Most package managers also provide the ``git-lfs`` client.
 Since, LFS is a rapidly evolving technology, package managers will help you keep up with new ``git-lfs`` releases.
 For example, Mac users with Homebrew_ can simply run ``brew install git-lfs`` and ``brew upgrade git-lfs``.
 
+.. _git-lfs-config:
+
+Configuring Git and Git LFS
+===========================
+
 Once ``git-lfs`` is installed, run
 
 .. code-block:: bash
@@ -90,7 +95,6 @@ For example, run:
 
 - If you are a member of the LSST GitHub organization you can use your GitHub username and password.
 - If you *also* have `GitHub's two-factor authentication <https://help.github.com/articles/about-two-factor-authentication/>`_ enabled, use a personal access token instead of a password. You can setup a personal token at https://github.com/settings/tokens.
-- If you are only interested in cloning or pulling, the 'Username' and 'Password' can be blank.
 
 Once your credentials are cached, you won't need to repeat this process on your system (:ref:`unless you opted for the cache-based credential helper <git-credential-helper>`).
 

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -31,7 +31,34 @@ Once ``git-lfs`` is installed, run
    git config --global lfs.batch false
    git lfs install
 
-to install the necessary hooks in your :file:`~/.gitconfig` file.
+to install the necessary configuration in your :file:`~/.gitconfig` file.
+
+Next add credentials for our git-lfs secondary storage systems to your :file:`~/.gitconfig` file.
+
+.. code-block:: bash
+
+[credential "https://lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com"]
+        helper = store
+[credential "https://s3.lsst.codes"]
+        helper = store
+
+Next add their authentication information to your :file:`~/.git-credentials` file.
+
+.. code-block:: bash
+https://:@lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com
+https://:@s3.lsst.codes
+
+
+If you will be anonymously authenticating then you must configure git to use no username and password with the git-lfs server. Add this to your :file:`~/.gitconfig` file.
+
+.. code-block:: bash
+https://:@lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com
+https://:@s3.lsst.codes
+
+Add this to your :file:`~/.git-credentials` file.
+
+.. code-block:: bash
+https://:@git-lfs.lsst.codes
 
 .. _git-lfs-auth:
 
@@ -61,13 +88,6 @@ For example, run:
 - If you are a member of the LSST GitHub organization you can use your GitHub username and password.
 - If you *also* have `GitHub's two-factor authentication <https://help.github.com/articles/about-two-factor-authentication/>`_ enabled, use a personal access token instead of a password. You can setup a personal token at https://github.com/settings/tokens.
 - If you are only interested in cloning or pulling, the 'Username' and 'Password' can be blank.
-
-Finally, the ``git clone`` will ask you to authenticate to ``s3.lsst.codes``::
-
-   Username for 'https://s3.lsst.codes': <Empty>
-   Password for 'https://s3.lsst.codes': <Empty>
-
-There is no username or password for LSST's S3 service.
 
 Once your credentials are cached, you won't need to repeat this process on your system (:ref:`unless you opted for the cache-based credential helper <git-credential-helper>`).
 

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -54,6 +54,7 @@ Next add their authentication information to your :file:`~/.git-credentials` fil
    https://:@lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com
    https://:@s3.lsst.codes
 
+.. _git-lfs-anonymous:
 
 If you will be anonymously authenticating then you must configure git to use no username and password with the git-lfs server. Add this to your :file:`~/.gitconfig` file.
 
@@ -90,11 +91,12 @@ For example, run:
 
 ``git clone`` will ask you to authenticate with DM's git-lfs server::
 
-   Username for 'https://git-lfs.lsst.codes': <GitHub username OR blank>
-   Password for 'https://<git>@git-lfs.lsst.codes': <GitHub password, token OR blank>
+   Username for 'https://git-lfs.lsst.codes': <GitHub username>
+   Password for 'https://<git>@git-lfs.lsst.codes': <GitHub password>
 
 - If you are a member of the LSST GitHub organization you can use your GitHub username and password.
 - If you *also* have `GitHub's two-factor authentication <https://help.github.com/articles/about-two-factor-authentication/>`_ enabled, use a personal access token instead of a password. You can setup a personal token at https://github.com/settings/tokens.
+- If you are only interested in cloning or pulling, :ref:`configure anonymous authentication<git-lfs-anonymous>` for the git-lfs server.
 
 Once your credentials are cached, you won't need to repeat this process on your system (:ref:`unless you opted for the cache-based credential helper <git-credential-helper>`).
 

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -37,31 +37,31 @@ Next add credentials for our git-lfs secondary storage systems to your :file:`~/
 
 .. code-block::
 
-[credential "https://lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com"]
-        helper = store
-[credential "https://s3.lsst.codes"]
-        helper = store
+   [credential "https://lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com"]
+           helper = store
+   [credential "https://s3.lsst.codes"]
+           helper = store
 
 Next add their authentication information to your :file:`~/.git-credentials` file.
 
 .. code-block::
    
-https://:@lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com
-https://:@s3.lsst.codes
+   https://:@lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com
+   https://:@s3.lsst.codes
 
 
 If you will be anonymously authenticating then you must configure git to use no username and password with the git-lfs server. Add this to your :file:`~/.gitconfig` file.
 
 .. code-block::
    
-https://:@lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com
-https://:@s3.lsst.codes
+   https://:@lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com
+   https://:@s3.lsst.codes
 
 Add this to your :file:`~/.git-credentials` file.
 
 .. code-block::
    
-https://:@git-lfs.lsst.codes
+   https://:@git-lfs.lsst.codes
 
 .. _git-lfs-auth:
 

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -35,7 +35,7 @@ to install the necessary configuration in your :file:`~/.gitconfig` file.
 
 Next add credentials for our git-lfs secondary storage systems to your :file:`~/.gitconfig` file.
 
-.. code-block::
+.. code-block:: text
 
    [credential "https://lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com"]
            helper = store
@@ -44,7 +44,7 @@ Next add credentials for our git-lfs secondary storage systems to your :file:`~/
 
 Next add their authentication information to your :file:`~/.git-credentials` file.
 
-.. code-block::
+.. code-block:: text
    
    https://:@lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com
    https://:@s3.lsst.codes
@@ -52,14 +52,14 @@ Next add their authentication information to your :file:`~/.git-credentials` fil
 
 If you will be anonymously authenticating then you must configure git to use no username and password with the git-lfs server. Add this to your :file:`~/.gitconfig` file.
 
-.. code-block::
+.. code-block:: text
    
    https://:@lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com
    https://:@s3.lsst.codes
 
 Add this to your :file:`~/.git-credentials` file.
 
-.. code-block::
+.. code-block:: text
    
    https://:@git-lfs.lsst.codes
 

--- a/tools/git_lfs.rst
+++ b/tools/git_lfs.rst
@@ -39,7 +39,7 @@ Once ``git-lfs`` is installed, run
 to configure Git to use Git LFS in your :file:`~/.gitconfig` file.
 
 Next, we need to tell Git that DM's LFS storage services don't need a password for reading.
-Begin by activating Git's `credential store`_ helper for DM's Git LFS storage services by pasting these lines into your :file:`~/.gitconfig` file:
+Begin by activating Git's `credential store`_ helper for DM's Git LFS storage services by adding these lines into your :file:`~/.gitconfig` file:
 
 .. code-block:: text
 
@@ -86,7 +86,7 @@ Then add cache anonymous access to the server by adding this line to your :file:
    
    https://:@git-lfs.lsst.codes
 
-**That's it. You're ready to clone any of DM's Git LFS managed repositories.**
+That's it. You're ready to clone any of DM's Git LFS managed repositories.
 
 .. _git-lfs-auth:
 

--- a/tools/snippets/git_lfs_git-credentials.txt
+++ b/tools/snippets/git_lfs_git-credentials.txt
@@ -1,0 +1,3 @@
+https://:@lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com
+https://:@s3.lsst.codes
+https://:@git-lfs.lsst.codes

--- a/tools/snippets/git_lfs_gitconfig.txt
+++ b/tools/snippets/git_lfs_gitconfig.txt
@@ -1,0 +1,9 @@
+# Cache anonymous access to DM Git LFS S3 servers
+[credential "https://lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com"]
+    helper = store
+[credential "https://s3.lsst.codes"]
+    helper = store
+
+# Cache anonymous access to DM Git LFS server
+[credential "https://git-lfs.lsst.codes"]
+    helper = store


### PR DESCRIPTION
* Reasoning: git-lfs 1.1.0+ doesn't accept empty username and passwords for the git-lfs server or secondary storage system. So the documentation needs to be updated.
* Add documentation to configure the git credential store to use empty username and passwords for the secondary storage systems and the git-lfs server.

	modified:   tools/git_lfs.rst